### PR TITLE
releases page github url corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is the result of merging and cleaning up a bunch of porn-blocking lists I've found scattered through the web. It currently has 11.457.459 domains and a redirect to the "Safe Browsing" versions of Google, DuckDuckGo, Bing, YouTube and Yandex.
 
-The list is split into 90MB chunks to avoid GitHub's [file size limit](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github). If you need a single file list it can be found on the [releases page](https://github.com/columndeeply/hosts/releases/tag/latest). The merged list will be updated once a month.
+The list is split into 90MB chunks to avoid GitHub's [file size limit](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github). If you need a single file list it can be found on the [releases page](https://github.com/columndeeply/hosts/releases/latest). The merged list will be updated once a month.
 
 # Usage
 You can use this list with most DNS based blockers (PiHole/Adguard Home/Technitium DNS/etc.) or directly by appending the list to your hosts file.


### PR DESCRIPTION
❌ https://github.com/columndeeply/hosts/releases/tag/latest
✅ https://github.com/columndeeply/hosts/releases/latest 